### PR TITLE
Improve multiplayer support, fixes

### DIFF
--- a/HorseWhistle/ModEntry.cs
+++ b/HorseWhistle/ModEntry.cs
@@ -80,7 +80,7 @@ namespace HorseWhistle
             if (!Context.IsPlayerFree)
                 return;
 
-            if (e.Button == _config.TeleportHorseKey && !Game1.player.isRidingHorse())
+            if (e.Button == _config.TeleportHorseKey && !Game1.player.isRidingHorse() && !Game1.player.isAnimatingMount)
             {
                 var horse = FindHorse();
                 if (horse == null) return;


### PR DESCRIPTION
This pull request, which modifies the update-code branch:

* Allows farmhands to whistle for horses at any location available to the host player. When used by farmhands, the whistle command will send a SMAPI multiplayer message to the host's mod, which will warp a horse.
* Prevents warping into the locations that may lose or remove horses. This includes the mineshaft (which removes horses on player exit) and any locations not provided by this mod's GetLocations method (e.g. unusual modded locations).
* Prevents whistling by players currently in the mounting animation.

Please let me know if there are any issues with this request.